### PR TITLE
ZeroDivisionError for graph with small number of nodes

### DIFF
--- a/fa2/fa2util.py
+++ b/fa2/fa2util.py
@@ -284,7 +284,10 @@ def adjustSpeedAndApplyForces(nodes, speed, speedEfficiency, jitterTolerance):
             speedEfficiency *= .5
         jt = max(jt, jitterTolerance)
 
-    targetSpeed = jt * speedEfficiency * totalEffectiveTraction / totalSwinging
+    if totalSwinging == 0:
+        targetSpeed = 1
+    else:
+        targetSpeed = jt * speedEfficiency * totalEffectiveTraction / totalSwinging
 
     if totalSwinging > jt * totalEffectiveTraction:
         if speedEfficiency > minSpeedEfficiency:


### PR DESCRIPTION
Hello,

First, let me thank you for this very good work. Cythonized version is incredibly faster than Python's one!

I found that `adjustSpeedAndApplyForces` can sometimes generate a `ZeroDivisionError` on very small graphes (around <5).
I checked the original Java code and it seems that the faulty line is there also... I suppose the same error could be raised.

Here is a possible fix for this.